### PR TITLE
Reset all store instances.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /*global VERSION*/
 
 import forEach from 'mout/array/forEach';
+import forOwn from 'mout/object/forOwn';
 import keys from 'mout/object/keys';
 import isFunction from 'mout/lang/isFunction';
 import isObject from 'mout/lang/isObject';
@@ -105,9 +106,21 @@ class Store {
         throw new Error('[riotx] [plugin] The plugin is not a function.');
       }
       p.apply(null, [this]);
-
     });
 
+  }
+
+  /**
+   * Reset store instance.
+   */
+  reset() {
+    this.name = null;
+    this._state = null;
+    this._actions = null;
+    this._mutations = null;
+    this._getters = null;
+    this._plugins = null;
+    this.off('*');
   }
 
   /**
@@ -320,10 +333,13 @@ class RiotX {
   }
 
   /**
-   * Reset riotx instance
+   * Reset all store instances at once.
    * @returns {RiotX} instance
    */
   reset() {
+    forOwn(this.stores || {}, store => {
+      store.reset();
+    });
     this.stores = {};
     return this;
   }

--- a/test/spec/index.js
+++ b/test/spec/index.js
@@ -34,20 +34,39 @@ describe('client-side specs', () => {
     assert(riotx.version !== '');
   });
 
-  it('reset riotx', () => {
+  it('reset riotx', done => {
     riotx.add(new riotx.Store({
-      name: 'test',
-      state: {
-        test: true
-      },
+      name: 'A',
+      state: {},
       actions: {},
       mutations: {},
       getters: {}
     }));
-    assert(riotx.get('test').name === 'test');
-    assert(Object.keys(riotx.stores).length === 1);
+    riotx.add(new riotx.Store({
+      name: 'B',
+      state: {},
+      actions: {},
+      mutations: {},
+      getters: {}
+    }));
+
+    const storeA = riotx.get('A');
+    let isCalled = false;
+    storeA.on('evt', () => {
+      isCalled = true;
+    });
+    assert(riotx.get('A').name === 'A');
+    assert(riotx.get('B').name === 'B');
+    assert(riotx.size() === 2);
     riotx.reset();
-    assert(Object.keys(riotx.stores).length === 0);
+    assert(!riotx.get('A'));
+    assert(!riotx.get('B'));
+    assert(riotx.size() === 0);
+    storeA.trigger('evt');
+    setTimeout(() => {
+      assert(!isCalled);
+      done();
+    }, 100);
   });
 
   it('mixin', () => {


### PR DESCRIPTION
Execute `riotx.reset()` to reset all store instances.

All store instances will be disposed and no more events will be fired from store instances.